### PR TITLE
Define two new DATM mode to be used with CLM: pi6hGSWP3 and 6hGSWP3

### DIFF
--- a/datm/cime_config/config_component.xml
+++ b/datm/cime_config/config_component.xml
@@ -10,7 +10,7 @@
        This file may have atm desc entries.
   -->
   <description modifier_mode="1">
-    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%MOSARTTEST][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p4-2018][%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304]"> Data driven ATM </desc>
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%MOSARTTEST][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p4-2018][%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304][%pi6hGSWP3][%6hGSWP3]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>
     <desc option="WISOQIA">QIAN with water isotopes</desc>
     <desc option="CRU"> CRUNCEP data set </desc>
@@ -27,6 +27,8 @@
     <desc option="JRA-RYF9091"> JRA55 Repeat Year Forcing v1.3 1990-1991</desc>
     <desc option="JRA-RYF0304"> JRA55 Repeat Year Forcing v1.3 2003-2004</desc>
     <desc option="ERA5">ERA5 interannual forcing</desc>
+    <desc option="pi6hGSWP3">GSWP3 data set with 6-hourly data, 1901-1930 climatology to simulate 1850</desc>
+    <desc option="6hGSWP3">GSWP3 data set with 6-hourly data</desc>
   </description>
 
   <entry id="COMP_ATM">
@@ -40,7 +42,7 @@
 
   <entry id="DATM_MODE">
     <type>char</type>
-    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRA_1p4_2018,ERA5</valid_values>
+    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRA_1p4_2018,ERA5,CLM6hGSWP3,CLMpi6hGSWP3</valid_values>
     <default_value>CORE2_NYF</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
@@ -61,6 +63,8 @@
       <value compset="DATM%1PT">1PT</value>
       <value compset="DATM%ERA5">ERA5</value>
       <value compset="DATM%CPLHIST">CPLHIST</value>
+      <value compset="DATM%pi6hGSWP3">CLMpi6hGSWP3</value>
+      <value compset="DATM%6hGSWP3">CLM6hGSWP3</value>
     </values>
   </entry>
 
@@ -214,16 +218,22 @@
       <value compset="2000.*_DATM%1PT">$DATM_YR_START</value>
       <value compset="1850.*_DATM%QIA">1</value>
       <value compset="1850.*_DATM%CRU">1</value>
+      <value compset="1850.*_DATM%pi6hGSWP3">1850</value>
       <value compset="1850.*_DATM%GSW">1</value>
       <value compset="HIST.*_DATM%QIA">1895</value>
       <value compset="HIST.*_DATM%CRU">1901</value>
+      <value compset="HIST.*_DATM%6hGSWP3">1901</value>
+      <value compset="HIST.*_DATM%pi6hGSWP3">1850</value>
       <value compset="HIST.*_DATM%GSW">1901</value>
       <value compset="HIST.*_DATM%NLDAS2">$DATM_YR_START</value>
       <value compset="20TR.*_DATM%QIA">1895</value>
       <value compset="20TR.*_DATM%CRU">1901</value>
+      <value compset="20TR.*_DATM%pi6hGSWP3">1850</value>
+      <value compset="20TR.*_DATM%6hGSWP3">1901</value>
       <value compset="20TR.*_DATM%GSW">1901</value>
       <value compset="SSP.*_DATM%QIA">$DATM_YR_START</value>
       <value compset="SSP.*_DATM%CRU">$DATM_YR_START</value>
+      <value compset="SSP.*_DATM%6hGSWP3">$DATM_YR_START</value>
       <value compset="SSP.*_DATM%GSW">$DATM_YR_START</value>
       <value compset="1850.*_DATM%CRU">1</value>
       <value compset="1850.*_DATM%GSW">1</value>
@@ -260,21 +270,27 @@
       <value compset="2000.*_DATM%1PT" grid="1x1_urbanc_alpha" >1</value>
       <value compset="1850.*_DATM%QIA">1948</value>
       <value compset="1850.*_DATM%CRU">1901</value>
+      <value compset="1850.*_DATM%pi6hGSWP3">1850</value>
       <value compset="1850.*_DATM%GSW">1901</value>
       <value compset="1850.*_DATM%NLDAS2">0</value>  <!-- Unsupported -->
       <value compset="2000.*_DATM%WISOQIA">2000</value>
       <value compset="2000.*_DATM%QIA">1972</value>
       <value compset="HIST.*_DATM%QIA">1948</value>
       <value compset="HIST.*_DATM%CRU">1901</value>
+      <value compset="HIST.*_DATM%6hGSWP3">1901</value>
+      <value compset="HIST.*_DATM%pi6hGSWP3">1850</value>
       <value compset="HIST.*_DATM%GSW">1901</value>
       <value compset="HIST.*_DATM%NLDAS2">0</value>  <!-- Unsupported -->
       <value compset="20TR.*_DATM%QIA">1948</value>
       <value compset="20TR.*_DATM%CRU">1901</value>
+      <value compset="20TR.*_DATM%pi6hGSWP3">1850</value>
+      <value compset="20TR.*_DATM%6hGSWP3">1901</value>
       <value compset="20TR.*_DATM%GSW">1901</value>
       <value compset="20TR.*_DATM%NLDAS2">0</value>  <!-- Unsupported -->
       <value compset="4804.*_DATM%QIA">1948</value>
       <value compset="SSP.*_DATM%QIA" >1995</value>
       <value compset="SSP.*_DATM%CRU" >2001</value>
+      <value compset="SSP.*_DATM%6hGSWP3" >2015</value>
       <value compset="SSP.*_DATM%GSW" >2001</value>
       <value compset="2003.*_DATM%QIA.*_TEST">2002</value>
       <value compset="1850.*_DATM%CRU">1901</value>
@@ -305,21 +321,27 @@
       <value   compset="2000.*_DATM%1PT" grid="1x1_urbanc_alpha" >2</value>
       <value   compset="1850.*_DATM%QIA">1972</value>
       <value   compset="1850.*_DATM%CRU">1920</value>
+      <value   compset="1850.*_DATM%pi6hGSWP3">1850</value>
       <value   compset="1850.*_DATM%GSW">1920</value>
       <value   compset="1850.*_DATM%NLDAS2">-1</value>  <!-- Unsupported -->
       <value   compset="2000.*_DATM%WISOQIA">2004</value>
       <value   compset="2000.*_DATM%QIA">2004</value>
       <value   compset="HIST.*_DATM%QIA">1972</value>
       <value   compset="HIST.*_DATM%CRU">1920</value>
+      <value   compset="HIST.*_DATM%pi6hGSWP3">1850</value>
+      <value   compset="HIST.*_DATM%6hGSWP3">2014</value>
       <value   compset="HIST.*_DATM%GSW">1920</value>
       <value   compset="HIST.*_DATM%NLDAS2">-1</value>  <!-- Unsupported -->
       <value   compset="20TR.*_DATM%QIA">1972</value>
       <value   compset="20TR.*_DATM%CRU">1920</value>
+      <value   compset="20TR.*_DATM%pi6hGSWP3">1850</value>
+      <value   compset="20TR.*_DATM%6hGSWP3">2014</value>
       <value   compset="20TR.*_DATM%GSW">1920</value>
       <value   compset="20TR.*_DATM%NLDAS2">-1</value>  <!-- Unsupported -->
       <value   compset="4804.*_DATM%QIA">2004</value>
       <value   compset="SSP.*_DATM%QIA">2004</value>
       <value   compset="SSP.*_DATM%CRU">2016</value>
+      <value   compset="SSP.*_DATM%6hGSWP3">2100</value>
       <value   compset="SSP.*_DATM%GSW">2014</value>
       <value   compset="2003.*_DATM%QIA.*_TEST">2003</value>
       <value   compset="1850.*_DATM%CRU">1920</value>

--- a/datm/cime_config/namelist_definition_datm.xml
+++ b/datm/cime_config/namelist_definition_datm.xml
@@ -22,6 +22,12 @@
       <value datm_mode="CLMCRUNCEPv7">
         CLMCRUNCEPv7.Solar,CLMCRUNCEPv7.Precip,CLMCRUNCEPv7.TPQW
       </value>
+      <value datm_mode="CLMpi6hGSWP3">
+        CLMpi6hGSWP3.Solar,CLMpi6hGSWP3.Precip,CLMpi6hGSWP3.TPQW
+      </value>
+      <value datm_mode="CLM6hGSWP3">
+        CLM6hGSWP3.Solar,CLM6hGSWP3.Precip,CLM6hGSWP3.TPQW
+      </value>
       <value datm_mode="CLMGSWP3v1">
         CLMGSWP3v1.Solar,CLMGSWP3v1.Precip,CLMGSWP3v1.TPQW
       </value>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -72,6 +72,20 @@
   CLMCRUNCEPv7.TPQW
 
   ========================
+  datm_mode CLMpi6hGSWP3: (DATM%pi6hGSWP3 in env_run.xml)
+  ========================
+  CLMpi6hGSWP3.Solar
+  CLMpi6hGSWP3.Precip
+  CLMpi6hGSWP3.TPQW
+
+  ========================
+  datm_mode CLM6hGSWP3: (DATM%6hGSWP3 in env_run.xml)
+  ========================
+  CLM6hGSWP3.Solar
+  CLM6hGSWP3.Precip
+  CLM6hGSWP3.TPQW
+
+  ========================
   datm_mode CLMNLDAS2: (DATM%NLDAS2 in env_run.xml)
   ========================
   CLMNLDAS2.Solar
@@ -440,6 +454,206 @@
     </stream_meshfile>
     <stream_datafiles>
       <file first_year="1901" last_year="2016">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.cruncep_qianFill.0.5d.v7.c160715/TPHWL6Hrly/clmforc.cruncep.V7.c2016.0.5d.TPQWL.%ym.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <var>TBOT     Sa_tbot</var>
+      <var>WIND     Sa_wind</var>
+      <var>QBOT     Sa_shum</var>
+      <var>PSRF     Sa_pbot</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>linear</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
+  <!-- ===================================  -->
+  <!-- datm_mode CLMpi6hGSWP3            -->
+  <!-- ===================================  -->
+
+  <stream_entry name="CLMpi6hGSWP3.Solar">
+    <stream_meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/clmforc.GSWP3.c2011.0.5x0.5.TPQWL.SCRIP.210520_ESMFmesh.nc</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file first_year="1850" last_year="1850">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.gswp3.0.5d.c180724/clima_1850-1900/clmforc.gswp3.0.5d.Solr.%ym.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <var>FSDS     Faxa_swdn</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>coszen</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
+  <stream_entry name="CLMpi6hGSWP3.Precip">
+    <stream_meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/clmforc.GSWP3.c2011.0.5x0.5.TPQWL.SCRIP.210520_ESMFmesh.nc</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file first_year="1850" last_year="1850">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.gswp3.0.5d.c180724/clima_1850-1900/clmforc.gswp3.0.5d.Prec.%ym.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <var>PRECTmms Faxa_precn</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>nearest</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
+  <stream_entry name="CLMpi6hGSWP3.TPQW">
+    <stream_meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/clmforc.GSWP3.c2011.0.5x0.5.TPQWL.SCRIP.210520_ESMFmesh.nc</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file first_year="1850" last_year="1850">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.gswp3.0.5d.c180724/clima_1850-1900/clmforc.gswp3.0.5d.TPQWL.%ym.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <var>TBOT     Sa_tbot</var>
+      <var>WIND     Sa_wind</var>
+      <var>QBOT     Sa_shum</var>
+      <var>PSRF     Sa_pbot</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>linear</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
+  <!-- ===================================  -->
+  <!-- datm_mode CLM6hGSWP3                 -->
+  <!-- ===================================  -->
+
+  <stream_entry name="CLM6hGSWP3.Solar">
+    <stream_meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/clmforc.GSWP3.c2011.0.5x0.5.TPQWL.SCRIP.210520_ESMFmesh.nc</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file first_year="1901" last_year="2014">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.gswp3.0.5d.c180724/Solar6Hrly/clmforc.gswp3.0.5d.Solr.%ym.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <var>FSDS     Faxa_swdn</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>coszen</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
+  <stream_entry name="CLM6hGSWP3.Precip">
+    <stream_meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/clmforc.GSWP3.c2011.0.5x0.5.TPQWL.SCRIP.210520_ESMFmesh.nc</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file first_year="1901" last_year="2014">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.gswp3.0.5d.c180724/Precip6Hrly/clmforc.gswp3.0.5d.Prec.%ym.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <var>PRECTmms Faxa_precn</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>nearest</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
+  <stream_entry name="CLM6hGSWP3.TPQW">
+    <stream_meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/clmforc.GSWP3.c2011.0.5x0.5.TPQWL.SCRIP.210520_ESMFmesh.nc</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file first_year="1901" last_year="2014">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.gswp3.0.5d.c180724/TPHWL6Hrly/clmforc.gswp3.0.5d.TPQWL.%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>TBOT     Sa_tbot</var>


### PR DESCRIPTION
### Description of changes

Define two new DATM mode to be used with CLM: 
pi6hGSWP3 -> uses GSWP3 forcing aggregated into 6-hourly data and averaged between 1901-1930 to mimic pre-industrial condition
6hGSWP3 -> uses historical GSWP3 forcing aggregated into 6-hourly data 

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial):

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):

Hashes used for testing:

